### PR TITLE
Ignore @types/vscode from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
       timezone: America/New_York
     reviewers:
       - "Shopify/sorbet"
+    ignore:
+      - dependency-name: "@types/vscode"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/mocha": "^9.0.0",
     "@types/node": "^17.0.21",
     "@types/uuid": "^8.3.4",
-    "@types/vscode": "^1.65.0",
+    "@types/vscode": "^1.63.0",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.14.0",
     "@vscode/test-electron": "^2.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -568,7 +568,7 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
   integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
-"@types/vscode@^1.65.0":
+"@types/vscode@^1.63.0":
   version "1.65.0"
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.65.0.tgz#042dd8d93c32ac62cb826cd0fa12376069d1f448"
   integrity sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==


### PR DESCRIPTION
Automatically bumping `@types/vscode` forces us to bump the engine as well, which drops support for older versions of vscode quicker than we would like.

It'd be good to support at least 2 versions back. I suggest we ignore this dependency and bump it manually, so that we can support older versions of vscode.