### PR TITLE
Publish the extension to the marketplace when creating releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,23 +11,18 @@ jobs:
         name: Checkout
 
       - uses: actions/setup-node@v2
-        name: Use Node.js 16.x
+        name: Use Node.js 17.x
         with:
-          node-version: "16"
+          node-version: "17"
           cache: "yarn"
 
       - name: 📦 Install dependencies
         run: yarn --frozen-lockfile
 
-      - name: 💅🏼 Lint
-        run: yarn lint
-
       - name: 🔨 Package
         run: yarn vsce package
 
-      - name: Upload assets to release
-        uses: Shopify/upload-to-release@master
-        with:
-          name: vscode-shopify-ruby.vsix
-          path: vscode-shopify-ruby.vsix
-          repo-token: ${{secrets.GITHUB_TOKEN }}
+      - name: Publish extension in the marketplace
+        run: node_modules/.bin/vsce publish --packagePath vscode-shopify-ruby.vsix
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
Change our publish workflow to publish our packaged extension in the marketplace according to the [docs](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#publishing-extensions).

I also updated the node version to match what we're using for development and removed the lint step. I don't think we need to lint before releasing, since we already lint on CI.