### PR TITLE
Add Sorbet and rdbg

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "Shopify.rubocop-lsp",
     "Shopify.vscode-shadowenv",
     "sorbet.sorbet-vscode-extension",
-    "koichisasada.vscode-rdbg"
+    "koichisasada.vscode-rdbg",
+    "itarato.byesig"
   ],
   "contributes": {
     "commands": [

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -19,6 +19,10 @@ export const DEFAULT_CONFIGS = [
     name: "formatOnSave",
     value: true,
   },
+  { section: "byesig", name: "fold", value: false },
+  { section: "byesig", name: "enabled", value: true },
+  { section: "byesig", name: "opacity", value: 0.5 },
+  { section: "byesig", name: "showIcon", value: false },
 ];
 
 export interface ConfigurationEntry {


### PR DESCRIPTION
Add Sorbet and ruby debug (rdbg) to the pack. We may want to add some configuration for the rdbg plugin, but let's at least include it for now.