### PR TITLE
Fix the rubocop lint configuration scopes

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 export const DEFAULT_CONFIGS = [
   { section: "ruby", name: "useBundler", value: true },
   { section: "ruby", name: "useLanguageServer", value: false },
-  { section: "ruby.lint", name: "rubocop", value: false },
+  { section: "ruby", name: "lint", value: { rubocop: false } },
   { section: "ruby", name: "codeCompletion", value: false },
   { section: "ruby", name: "intellisense", value: false },
   { section: "ruby", name: "format", value: false },


### PR DESCRIPTION
I noticed that this configuration was not getting applied when approving overrides. The issue was that the scope was incorrect.

### Tophat

1. Delete your Ruby related configs in your JSON settings
2. On this branch, start the debug mode with F5
3. Accept overrides
4. Verify that `ruby.lint.rubocop` shows up as `false`