### PR TITLE
Display full config name and value when prompting override

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -118,6 +118,7 @@ export class Configuration {
     }
 
     const configName = `${section}.${name}`;
+    const printableValue = JSON.stringify(value);
     const existingConfig = config.inspect(name);
 
     // If the value configured already matches the default, don't prompt
@@ -136,7 +137,7 @@ export class Configuration {
         this.valuesAreDifferent(existingConfig.globalLanguageValue, value))
     ) {
       return this.promptOverride(
-        `The existing configuration for ${configName} doesn't match our suggested default (${value})`,
+        `The existing configuration for ${configName} doesn't match our suggested default (${printableValue})`,
         name
       );
     }
@@ -153,13 +154,13 @@ export class Configuration {
         ))
     ) {
       return this.promptOverride(
-        `The existing workspace configuration for ${configName} doesn't match our suggested default (${value})`,
+        `The existing workspace configuration for ${configName} doesn't match our suggested default (${printableValue})`,
         name
       );
     }
 
     return this.promptOverride(
-      `No configuration found for ${configName}. Would you like to apply the suggested default (${value})?`,
+      `No configuration found for ${configName}. Would you like to apply the suggested default (${printableValue})?`,
       name
     );
   }


### PR DESCRIPTION
When prompting overrides, display the full name of the config and the value we want to override it with.

#### Tophat

1. Remove any existing configuration that is set by the [extension pack](https://github.com/Shopify/vscode-shopify-ruby/blob/main/src/configuration.ts#L3-L26)
2. Start the plugin on this branch with F5
3. Select the option to decide the override for each setting
4. Verify that the full config name and value is displayed