### PR TITLE
Use stringify to compare objects

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -121,9 +121,8 @@ export class Configuration {
     // If the value configured already matches the default, don't prompt
     if (
       existingConfig &&
-      (JSON.stringify(existingConfig.globalValue) === JSON.stringify(value) ||
-        JSON.stringify(existingConfig.globalLanguageValue) ===
-          JSON.stringify(value))
+      (!this.valuesAreDifferent(existingConfig.globalValue, value) ||
+        !this.valuesAreDifferent(existingConfig.globalLanguageValue, value))
     ) {
       return false;
     }


### PR DESCRIPTION
I noticed that selecting override for `lint.rubocop` would never stop re-prompting. The reason is because comparing two objects always returns `false` even if their attributes are the same.

We can safely compare values using `JSON.stringify`, which will then match if all of the attributes are the same.


### Tophat

1. Delete all of the extension pack configs
2. Start the extension on this branch
3. Choose the option to select each override
4. Accept each override individually
5. Reload the window
6. Verify you do not get prompted again for `lint.rubocop`