### PR TITLE
Remove the alpha from our extension version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
-## [0.0.1-alpha]
+## [0.0.1]
 
 - Initial release including Ruby, rubocop-lsp, Sorbet, shadowenv, byesig and rdbg

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/Shopify/vscode-shopify-ruby"
   },
-  "version": "0.0.1-alpha",
+  "version": "0.0.1",
   "engines": {
     "vscode": "^1.63.0"
   },


### PR DESCRIPTION
When trying to publish to the marketplace, we discovered that it does not accept prerelease versions and thus `alpha` or `beta` at the end will make it reject the publish attempt.

Therefore, this PR removes the alpha from our version.