### PR TITLE
Change name to ruby-extensions-pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This extension pack contains an opinionated collection of pre-configured extensi
 
 ## Usage
 
-Search for `vscode-shopify-ruby` in the extensions tab and click install.
+Search for `ruby-extensions-pack` in the extensions tab and click install.
 
 When activated, this extension will prompt you about overriding your existing configuration to use the recommended defaults.
 You may want to backup your `settings.json` file before trying this extension out.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ruby",
+  "name": "ruby-extensions-pack",
   "displayName": "Ruby",
   "description": "An opinionated and auto-configured set of extensions for Ruby development",
   "license": "MIT",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -57,10 +57,12 @@ export interface ConfigurationStore {
 }
 
 // We use the extension version as part of the key, so that we prompt again in case any of the defaults have changed
-const EXTENSION_VERSION =
-  vscode.extensions.getExtension("shopify.ruby")!.packageJSON.version;
-const CANCELLED_OVERRIDES_KEY = `shopify.ruby.${EXTENSION_VERSION}.cancelled_overrides`;
-const APPROVED_ALL_OVERRIDES_KEY = `shopify.ruby.${EXTENSION_VERSION}.approved_all_overrides`;
+const EXTENSION_NAME = "ruby-extensions-pack";
+const EXTENSION_VERSION = vscode.extensions.getExtension(
+  `shopify.${EXTENSION_NAME}`
+)!.packageJSON.version;
+const CANCELLED_OVERRIDES_KEY = `shopify.${EXTENSION_NAME}.${EXTENSION_VERSION}.cancelled_overrides`;
+const APPROVED_ALL_OVERRIDES_KEY = `shopify.${EXTENSION_NAME}.${EXTENSION_VERSION}.approved_all_overrides`;
 
 export enum OverridesStatus {
   ApprovedAll = "approvedAll",
@@ -232,7 +234,9 @@ export class Configuration {
     // Otherwise, try to find a previous override status
     const previousApprovalKey = this.context.globalState
       .keys()
-      .find((key) => key.match(/shopify\.ruby\..*\.approved_all_overrides/));
+      .find((key) =>
+        key.match(/shopify\.ruby-extensions-pack\..*\.approved_all_overrides/)
+      );
 
     if (previousApprovalKey === undefined) {
       return undefined;

--- a/src/test/suite/configuration.test.ts
+++ b/src/test/suite/configuration.test.ts
@@ -47,12 +47,15 @@ class FakeStore implements ConfigurationStore {
 
 suite("Configuration suite", () => {
   test("automatic configuration sets defaults", () => {
-    const extensionVersion =
-      vscode.extensions.getExtension("shopify.ruby")!.packageJSON.version;
+    const extensionName = "ruby-extensions-pack";
+    const extensionVersion = vscode.extensions.getExtension(
+      `shopify.${extensionName}`
+    )!.packageJSON.version;
     const context = {
       globalState: {
         get: (name) =>
-          name === `shopify.ruby.${extensionVersion}.approved_all_overrides`
+          name ===
+          `shopify.${extensionName}.${extensionVersion}.approved_all_overrides`
             ? OverridesStatus.ApprovedAll
             : undefined,
       },


### PR DESCRIPTION
The marketplace [changed uniqueness](https://github.com/microsoft/vsmarketplace/issues/354) to be based on the extension's `name` instead of the `identifier`. This applies only to new extensions (existing ones are not affected), but it means that we can't publish the pack under the name `ruby` anymore.

This PR changes the plugin name to be `ruby-extensions-pack` (notice that `ruby-extension-pack` is also taken).