### PR TITLE
Add line trimming and final new line insertion

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -23,6 +23,8 @@ export const DEFAULT_CONFIGS = [
   { section: "byesig", name: "enabled", value: true },
   { section: "byesig", name: "opacity", value: 0.5 },
   { section: "byesig", name: "showIcon", value: false },
+  { section: "files", name: "trimTrailingWhitespace", value: true },
+  { section: "files", name: "insertFinalNewline", value: true },
 ];
 
 export interface ConfigurationEntry {


### PR DESCRIPTION
Add automatic white space trimming and new line insertion to our configs. Both are `false` by default, but then we either catch them with linters or even in PR reviews, so might as well have it automatically configured.