### PR TITLE
Run publish only on release create

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Release
 
-on: [release]
+on:
+  release:
+    types: [created]
 
 jobs:
   release:


### PR DESCRIPTION
Closes #60

We are currently triggering multiple publish actions when creating a single release through the GitHub UI. Based on the [docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release), I believe this is the right solution to only trigger it once when creating the release.