### PR TITLE
Add a link to marketplace page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This extension pack contains an opinionated collection of pre-configured extensi
 
 ## Usage
 
-Search for `ruby-extensions-pack` in the extensions tab and click install.
+Search for [`ruby-extensions-pack`](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-extensions-pack) in the extensions tab and click install.
 
 When activated, this extension will prompt you about overriding your existing configuration to use the recommended defaults.
 You may want to backup your `settings.json` file before trying this extension out.


### PR DESCRIPTION
It'd be nice if we can also link to the extension page from the readme without manually searching it 🙂 
(I'm used to browse extensions on GH and click links to their marketplace)

I know the readme will also appear in the extension page so the link to it will redirect back to itself (or just do nothing?). But I guess that'll be fine.