### PR TITLE
Remove the rubocop-lsp plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   ],
   "extensionPack": [
     "rebornix.ruby",
-    "Shopify.rubocop-lsp",
     "Shopify.vscode-shadowenv",
     "sorbet.sorbet-vscode-extension",
     "koichisasada.vscode-rdbg",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -11,7 +11,7 @@ export const DEFAULT_CONFIGS = [
     scope: { languageId: "ruby" },
     section: "editor",
     name: "defaultFormatter",
-    value: "Shopify.rubocop-lsp",
+    value: "Shopify.ruby-lsp",
   },
   {
     scope: { languageId: "ruby" },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,11 +3,6 @@ import * as vscode from "vscode";
 import { Configuration } from "./configuration";
 
 export async function activate(context: vscode.ExtensionContext) {
-  // If rubocop-lsp is activated before shadowenv, then it cannot find the right gem path and the server doesn't start
-  // This workaround just activates shadowenv and restarts the LSP after, to make sure it starts properly
-  vscode.extensions.getExtension("shopify.vscode-shadowenv")?.activate();
-  vscode.commands.executeCommand("rubocop-lsp.restart");
-
   const configuration = new Configuration(vscode.workspace, context);
   configuration.applyDefaults();
 


### PR DESCRIPTION
Continuation of #85.

Remove the `rubocop-lsp` from the pack, change the default formatter to be the `ruby-lsp` and prompt users to swap the `rubocop-lsp` gem for the `ruby-lsp` in case the gem is still present.

I attempted to be smart about it and add a button for removing `rubocop-lsp` with `bundle remove` and then adding the `ruby-lsp`, but depending on how the Gemfile groups are organized the results can vary. So, I ended up picking the simple path and just made it display a modal prompting the user to take the action manually.

### Manual tests

1. Start the plugin on this branch
2. On the opened window, navigate to a project that uses the `rubocop-lsp`
3. Verify you get prompted with a modal