### PR TITLE
Bump version to 0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.0.3]
+
+- Add the Ruby LSP to the pack (https://github.com/Shopify/vscode-shopify-ruby/pull/85)
+- Remove rubocop-lsp from the pack (https://github.com/Shopify/vscode-shopify-ruby/pull/86)
+
 ## [0.0.2]
 
 - Fix equality check when deciding each override (#63)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/Shopify/vscode-shopify-ruby"
   },
-  "version": "0.0.2",
+  "version": "0.0.3",
   "engines": {
     "vscode": "^1.63.0"
   },


### PR DESCRIPTION
Bump version to 0.0.3 to include the Ruby LSP and remove the rubocop-lsp.