### PR TITLE
Cleanup previous override approvals

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -261,11 +261,10 @@ export class Configuration {
     }
 
     // Otherwise, try to find a previous override status
-    const previousApprovalKey = this.context.globalState
-      .keys()
-      .find((key) =>
-        key.match(/shopify\.ruby-extensions-pack\..*\.approved_all_overrides/)
-      );
+    const existingKeys = this.context.globalState.keys();
+    const previousApprovalKey = existingKeys.find((key) =>
+      key.match(/shopify\.ruby-extensions-pack\..*\.approved_all_overrides/)
+    );
 
     if (previousApprovalKey === undefined) {
       return undefined;
@@ -277,6 +276,11 @@ export class Configuration {
         OverridesStatus.ApprovedAll &&
       this.allSettingsMatch()
     ) {
+      // Delete previous entries
+      existingKeys.forEach((key) => {
+        this.context.globalState.update(key, undefined);
+      });
+
       this.context.globalState.update(
         APPROVED_ALL_OVERRIDES_KEY,
         OverridesStatus.ApprovedAll

--- a/src/test/suite/configuration.test.ts
+++ b/src/test/suite/configuration.test.ts
@@ -38,10 +38,41 @@ class FakeStore implements ConfigurationStore {
       ) => {
         return (this.storage[`${section}.${name}`] = value);
       },
-      inspect: (_name: string) => {
-        return {};
+      inspect: (name: string) => {
+        return {
+          globalValue: this.storage[`${section}.${name}`],
+        };
       },
     };
+  }
+}
+
+class FakeGlobalState implements vscode.Memento {
+  private storage: { [key: string]: any } = {};
+
+  constructor() {
+    this.storage = {};
+  }
+
+  update(key: string, value: any): Thenable<void> {
+    if (value === undefined) {
+      delete this.storage[key];
+      return Promise.resolve();
+    }
+
+    return (this.storage[key] = value);
+  }
+
+  get(name: string) {
+    return this.storage[name];
+  }
+
+  keys() {
+    return Object.keys(this.storage);
+  }
+
+  setKeysForSync(_keys: ReadonlyArray<string>): void {
+    // noop
   }
 }
 
@@ -51,15 +82,16 @@ suite("Configuration suite", () => {
     const extensionVersion = vscode.extensions.getExtension(
       `shopify.${extensionName}`
     )!.packageJSON.version;
+
+    const globalState = new FakeGlobalState();
+    globalState.update(
+      `shopify.${extensionName}.${extensionVersion}.approved_all_overrides`,
+      OverridesStatus.ApprovedAll
+    );
+
     const context = {
-      globalState: {
-        get: (name) =>
-          name ===
-          `shopify.${extensionName}.${extensionVersion}.approved_all_overrides`
-            ? OverridesStatus.ApprovedAll
-            : undefined,
-      },
-    } as vscode.ExtensionContext;
+      globalState,
+    } as unknown as vscode.ExtensionContext;
     const store = new FakeStore();
     const config = new Configuration(store, context);
     config.applyDefaults();
@@ -67,5 +99,51 @@ suite("Configuration suite", () => {
     DEFAULT_CONFIGS.forEach(({ section, name, value }) => {
       assert.strictEqual(store.get(section, name), value);
     });
+  });
+
+  test("previous approvals are cleaned up if all settings match", () => {
+    const extensionName = "ruby-extensions-pack";
+    const extensionVersion = vscode.extensions.getExtension(
+      `shopify.${extensionName}`
+    )!.packageJSON.version;
+
+    // Save an approval from a previous extension version
+    const globalState = new FakeGlobalState();
+    globalState.update(
+      `shopify.${extensionName}.0.0.1.approved_all_overrides`,
+      OverridesStatus.ApprovedAll
+    );
+
+    const context = { globalState } as unknown as vscode.ExtensionContext;
+    const store = new FakeStore();
+
+    // Update all settings to match the expected
+    DEFAULT_CONFIGS.forEach(async ({ scope, section, name, value }) => {
+      const entry = store.getConfiguration(section, scope);
+      entry.update(name, value, true, true);
+    });
+
+    // Verify the previous approval is set
+    assert.strictEqual(1, globalState.keys().length);
+    assert.strictEqual(
+      globalState.get(`shopify.${extensionName}.0.0.1.approved_all_overrides`),
+      OverridesStatus.ApprovedAll
+    );
+
+    const config = new Configuration(store, context);
+    config.applyDefaults();
+
+    // Verify that the previous approval was cleaned up and passed to the current version
+    assert.strictEqual(1, globalState.keys().length);
+    assert.strictEqual(
+      globalState.get(`shopify.${extensionName}.0.0.1.approved_all_overrides`),
+      undefined
+    );
+    assert.strictEqual(
+      globalState.get(
+        `shopify.${extensionName}.${extensionVersion}.approved_all_overrides`
+      ),
+      OverridesStatus.ApprovedAll
+    );
   });
 });


### PR DESCRIPTION
### Motivation

For every new version, we were creating a new entry in global state for remembering whether users had approved all overrides. However, this keeps polluting the global state, so we should clean up old entries when migrating to a new version.

### Implementation

- Go through every old key and delete the entries from global state before saving the approval for the current plugin version. This ensures that only one version will remain, the one for the current extension version
- Took the opportunity to improve our tests a little bit, introducing a fake global state