### PR TITLE
Warn users about workspace settings shadowing recommended defaults

### DIFF
--- a/src/configurationStore.ts
+++ b/src/configurationStore.ts
@@ -1,0 +1,42 @@
+import * as vscode from "vscode";
+
+const EXTENSION_NAME = "ruby-extensions-pack";
+const EXTENSION_VERSION = vscode.extensions.getExtension(
+  `shopify.${EXTENSION_NAME}`
+)!.packageJSON.version;
+export const CANCELLED_OVERRIDES_KEY = `shopify.${EXTENSION_NAME}.${EXTENSION_VERSION}.cancelled_overrides`;
+export const APPROVED_ALL_OVERRIDES_KEY = `shopify.${EXTENSION_NAME}.${EXTENSION_VERSION}.approved_all_overrides`;
+export const SHADOWED_SETTINGS_KEY = `shopify.${EXTENSION_NAME}.${EXTENSION_VERSION}.shadowed_settings`;
+
+export type ConfigurationInfo =
+  | {
+      globalValue?: any;
+      workspaceValue?: any;
+      workspaceFolderValue?: any;
+      globalLanguageValue?: any;
+      workspaceLanguageValue?: any;
+      workspaceFolderLanguageValue?: any;
+    }
+  | undefined;
+
+export interface ConfigurationEntry {
+  update(
+    section: string,
+    value: any,
+    configurationTarget?:
+      | boolean
+      | vscode.ConfigurationTarget
+      | null
+      | undefined,
+    overrideInLanguage?: boolean | undefined
+  ): Thenable<void>;
+
+  inspect(section: string): ConfigurationInfo;
+}
+
+export interface ConfigurationStore {
+  getConfiguration(
+    section: string,
+    scope: vscode.ConfigurationScope | null | undefined
+  ): ConfigurationEntry;
+}

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -1,0 +1,150 @@
+import * as vscode from "vscode";
+
+import {
+  ConfigurationEntry,
+  ConfigurationStore,
+  ConfigurationInfo,
+  CANCELLED_OVERRIDES_KEY,
+} from "./configurationStore";
+
+export enum OverrideType {
+  Global = "Override",
+  Workspace = "Override workspace",
+  Both = "Override both",
+  None = "Cancel",
+}
+
+export class Setting {
+  public name: string;
+  public shadowedByWorkspaceSetting: boolean;
+  private section: string;
+  private value: any;
+  private scope?: { languageId: string };
+  private configurationStore: ConfigurationStore;
+  private configurationEntry: ConfigurationEntry;
+  private existingConfig: ConfigurationInfo;
+  private context: vscode.ExtensionContext;
+
+  constructor(
+    context: vscode.ExtensionContext,
+    configurationStore: ConfigurationStore,
+    section: string,
+    name: string,
+    value: any,
+    scope?: { languageId: string }
+  ) {
+    this.context = context;
+    this.configurationStore = configurationStore;
+    this.section = section;
+    this.name = name;
+    this.value = value;
+    this.scope = scope;
+
+    this.configurationEntry = this.configurationStore.getConfiguration(
+      this.section,
+      this.scope
+    );
+    this.existingConfig = this.configurationEntry.inspect(this.name);
+    this.shadowedByWorkspaceSetting = this.shadowed();
+  }
+
+  match(): boolean {
+    return (
+      JSON.stringify(this.existingConfig?.globalValue) ===
+        JSON.stringify(this.value) ||
+      JSON.stringify(this.existingConfig?.globalLanguageValue) ===
+        JSON.stringify(this.value)
+    );
+  }
+
+  needsOverride(): boolean {
+    return this.existingConfig === undefined || !this.match();
+  }
+
+  update(type: OverrideType = OverrideType.Global): void {
+    if (type === OverrideType.Both) {
+      this.configurationEntry.update(this.name, this.value, true, true);
+      this.configurationEntry.update(this.name, this.value, false, true);
+    } else {
+      this.configurationEntry.update(
+        this.name,
+        this.value,
+        type === OverrideType.Global,
+        true
+      );
+    }
+  }
+
+  fullName(): string {
+    return `${this.section}.${this.name}`;
+  }
+
+  printableValue(): string {
+    return JSON.stringify(this.value);
+  }
+
+  async promptOverride(): Promise<OverrideType> {
+    // If the user cancelled the override or if the setting does not need, don't prompt
+    if (
+      this.context.globalState.get(`${CANCELLED_OVERRIDES_KEY}.${this.name}`) ||
+      !this.needsOverride()
+    ) {
+      return OverrideType.None;
+    }
+
+    let message = `The setting ${this.fullName()} doesn't match our recommendation (${this.printableValue()})`;
+    let options: OverrideType[] = [OverrideType.Global, OverrideType.None];
+
+    if (this.shadowedByWorkspaceSetting) {
+      message = message.concat(" and is shadowed by a workspace setting");
+      options = [
+        OverrideType.Global,
+        OverrideType.Workspace,
+        OverrideType.Both,
+        OverrideType.None,
+      ];
+    }
+
+    const response = await vscode.window.showInformationMessage(
+      message,
+      ...options
+    );
+
+    if (response === "Cancel") {
+      this.context.globalState.update(
+        `${CANCELLED_OVERRIDES_KEY}.${this.name}`,
+        true
+      );
+    }
+
+    return response ?? OverrideType.None;
+  }
+
+  private valuesAreDifferent(config: any, value: any) {
+    return (
+      config !== undefined && JSON.stringify(config) !== JSON.stringify(value)
+    );
+  }
+
+  private shadowed(): boolean {
+    return Boolean(
+      this.existingConfig &&
+        (this.valuesAreDifferent(
+          this.existingConfig.workspaceValue,
+          this.value
+        ) ||
+          this.valuesAreDifferent(
+            this.existingConfig.workspaceFolderValue,
+            this.value
+          ) ||
+          this.valuesAreDifferent(
+            this.existingConfig.workspaceLanguageValue,
+            this.value
+          ) ||
+          this.valuesAreDifferent(
+            this.existingConfig.workspaceFolderLanguageValue,
+            this.value
+          ))
+    );
+  }
+}

--- a/src/test/fakeStore.ts
+++ b/src/test/fakeStore.ts
@@ -1,0 +1,47 @@
+import * as vscode from "vscode";
+
+import { ConfigurationEntry, ConfigurationStore } from "../configurationStore";
+
+export default class FakeStore implements ConfigurationStore {
+  private storage: { [key: string]: any } = {};
+  private workspaceStorage: { [key: string]: any } = {};
+
+  constructor() {
+    this.storage = {};
+    this.workspaceStorage = {};
+  }
+
+  get(section: string, name: string) {
+    return this.storage[`${section}.${name}`];
+  }
+
+  addToWorkspace(section: string, name: string, value: any) {
+    this.workspaceStorage[`${section}.${name}`] = value;
+  }
+
+  getConfiguration(
+    section: string,
+    _scope: vscode.ConfigurationScope | null | undefined
+  ): ConfigurationEntry {
+    return {
+      update: (
+        name: string,
+        value: any,
+        _configurationTarget:
+          | boolean
+          | vscode.ConfigurationTarget
+          | null
+          | undefined,
+        _overrideInLanguage: boolean | undefined
+      ) => {
+        return (this.storage[`${section}.${name}`] = value);
+      },
+      inspect: (name: string) => {
+        return {
+          globalValue: this.storage[`${section}.${name}`],
+          workspaceValue: this.workspaceStorage[`${section}.${name}`],
+        };
+      },
+    };
+  }
+}

--- a/src/test/fakeStore.ts
+++ b/src/test/fakeStore.ts
@@ -11,8 +11,12 @@ export default class FakeStore implements ConfigurationStore {
     this.workspaceStorage = {};
   }
 
-  get(section: string, name: string) {
-    return this.storage[`${section}.${name}`];
+  get(section: string, name: string, globalStore = true) {
+    if (globalStore) {
+      return this.storage[`${section}.${name}`];
+    } else {
+      return this.workspaceStorage[`${section}.${name}`];
+    }
   }
 
   addToWorkspace(section: string, name: string, value: any) {
@@ -27,14 +31,18 @@ export default class FakeStore implements ConfigurationStore {
       update: (
         name: string,
         value: any,
-        _configurationTarget:
+        configurationTarget:
           | boolean
           | vscode.ConfigurationTarget
           | null
           | undefined,
         _overrideInLanguage: boolean | undefined
       ) => {
-        return (this.storage[`${section}.${name}`] = value);
+        if (configurationTarget) {
+          return (this.storage[`${section}.${name}`] = value);
+        } else {
+          return (this.workspaceStorage[`${section}.${name}`] = value);
+        }
       },
       inspect: (name: string) => {
         return {

--- a/src/test/suite/configuration.test.ts
+++ b/src/test/suite/configuration.test.ts
@@ -3,49 +3,11 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 
 import {
-  ConfigurationEntry,
-  ConfigurationStore,
   Configuration,
   DEFAULT_CONFIGS,
   OverridesStatus,
 } from "../../configuration";
-
-class FakeStore implements ConfigurationStore {
-  private storage: { [key: string]: any } = {};
-
-  constructor() {
-    this.storage = {};
-  }
-
-  get(section: string, name: string) {
-    return this.storage[`${section}.${name}`];
-  }
-
-  getConfiguration(
-    section: string,
-    _scope: vscode.ConfigurationScope | null | undefined
-  ): ConfigurationEntry {
-    return {
-      update: (
-        name: string,
-        value: any,
-        _configurationTarget:
-          | boolean
-          | vscode.ConfigurationTarget
-          | null
-          | undefined,
-        _overrideInLanguage: boolean | undefined
-      ) => {
-        return (this.storage[`${section}.${name}`] = value);
-      },
-      inspect: (name: string) => {
-        return {
-          globalValue: this.storage[`${section}.${name}`],
-        };
-      },
-    };
-  }
-}
+import FakeStore from "../fakeStore";
 
 class FakeGlobalState implements vscode.Memento {
   private storage: { [key: string]: any } = {};

--- a/src/test/suite/setting.test.ts
+++ b/src/test/suite/setting.test.ts
@@ -1,0 +1,163 @@
+import * as assert from "assert";
+
+import * as vscode from "vscode";
+
+import FakeStore from "../fakeStore";
+import { Setting } from "../../setting";
+
+suite("Setting suite", () => {
+  test("match returns true if existing value matches", () => {
+    const store = new FakeStore();
+    store
+      .getConfiguration("editor", undefined)
+      .update("defaultFormatter", "Shopify.ruby-lsp", true, true);
+
+    const setting = new Setting(
+      {} as vscode.ExtensionContext,
+      store,
+      "editor",
+      "defaultFormatter",
+      "Shopify.ruby-lsp",
+      undefined
+    );
+
+    assert.strictEqual(setting.match(), true);
+  });
+
+  test("match returns false if existing value is different", () => {
+    const store = new FakeStore();
+    store
+      .getConfiguration("editor", undefined)
+      .update("defaultFormatter", "Shopify.some-other-formatter", true, true);
+
+    const setting = new Setting(
+      {} as vscode.ExtensionContext,
+      store,
+      "editor",
+      "defaultFormatter",
+      "Shopify.ruby-lsp",
+      undefined
+    );
+
+    assert.strictEqual(setting.match(), false);
+  });
+
+  test("needsOverride returns true if existing config is undefined", () => {
+    const store = new FakeStore();
+    const setting = new Setting(
+      {} as vscode.ExtensionContext,
+      store,
+      "editor",
+      "defaultFormatter",
+      "Shopify.ruby-lsp",
+      undefined
+    );
+
+    assert.strictEqual(setting.needsOverride(), true);
+  });
+
+  test("needsOverride returns true if existing config is has a different value", () => {
+    const store = new FakeStore();
+    store
+      .getConfiguration("editor", undefined)
+      .update("defaultFormatter", "Shopify.some-other-formatter", true, true);
+
+    const setting = new Setting(
+      {} as vscode.ExtensionContext,
+      store,
+      "editor",
+      "defaultFormatter",
+      "Shopify.ruby-lsp",
+      undefined
+    );
+
+    assert.strictEqual(setting.needsOverride(), true);
+  });
+
+  test("needsOverride returns false if existing config exists and matches", () => {
+    const store = new FakeStore();
+    store
+      .getConfiguration("editor", undefined)
+      .update("defaultFormatter", "Shopify.ruby-lsp", true, true);
+
+    const setting = new Setting(
+      {} as vscode.ExtensionContext,
+      store,
+      "editor",
+      "defaultFormatter",
+      "Shopify.ruby-lsp",
+      undefined
+    );
+
+    assert.strictEqual(setting.needsOverride(), false);
+  });
+
+  test("update changes the value of the setting in the store", () => {
+    const store = new FakeStore();
+    store
+      .getConfiguration("editor", undefined)
+      .update("defaultFormatter", "Shopify.some-other-formatter", true, true);
+
+    const setting = new Setting(
+      {} as vscode.ExtensionContext,
+      store,
+      "editor",
+      "defaultFormatter",
+      "Shopify.ruby-lsp",
+      undefined
+    );
+
+    setting.update();
+
+    assert.strictEqual(
+      store.get("editor", "defaultFormatter"),
+      "Shopify.ruby-lsp"
+    );
+  });
+
+  test("full name returns section and name", () => {
+    const setting = new Setting(
+      {} as vscode.ExtensionContext,
+      new FakeStore(),
+      "editor",
+      "defaultFormatter",
+      "Shopify.ruby-lsp",
+      undefined
+    );
+
+    assert.strictEqual(setting.fullName(), "editor.defaultFormatter");
+  });
+
+  test("printable value returns JSON string", () => {
+    const setting = new Setting(
+      {} as vscode.ExtensionContext,
+      new FakeStore(),
+      "section",
+      "name",
+      { key: "value" },
+      undefined
+    );
+
+    assert.strictEqual(setting.printableValue(), '{"key":"value"}');
+  });
+
+  test("shadowedByWorkspaceSetting returns true if a workspace value exists", () => {
+    const store = new FakeStore();
+    store.addToWorkspace(
+      "editor",
+      "defaultFormatter",
+      "Shopify.other-formatter"
+    );
+
+    const setting = new Setting(
+      {} as vscode.ExtensionContext,
+      store,
+      "editor",
+      "defaultFormatter",
+      "Shopify.ruby-lsp",
+      undefined
+    );
+
+    assert.strictEqual(setting.shadowedByWorkspaceSetting, true);
+  });
+});

--- a/src/test/suite/setting.test.ts
+++ b/src/test/suite/setting.test.ts
@@ -3,7 +3,7 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 
 import FakeStore from "../fakeStore";
-import { Setting } from "../../setting";
+import { OverrideType, Setting } from "../../setting";
 
 suite("Setting suite", () => {
   test("match returns true if existing value matches", () => {
@@ -111,6 +111,53 @@ suite("Setting suite", () => {
 
     assert.strictEqual(
       store.get("editor", "defaultFormatter"),
+      "Shopify.ruby-lsp"
+    );
+    assert.strictEqual(
+      store.get("editor", "defaultFormatter", false),
+      undefined
+    );
+  });
+
+  test("update both changes the value of global and workspace settings", () => {
+    const store = new FakeStore();
+    const setting = new Setting(
+      {} as vscode.ExtensionContext,
+      store,
+      "editor",
+      "defaultFormatter",
+      "Shopify.ruby-lsp",
+      undefined
+    );
+
+    setting.update(OverrideType.Both);
+
+    assert.strictEqual(
+      store.get("editor", "defaultFormatter"),
+      "Shopify.ruby-lsp"
+    );
+    assert.strictEqual(
+      store.get("editor", "defaultFormatter", false),
+      "Shopify.ruby-lsp"
+    );
+  });
+
+  test("update can change only workspace settings", () => {
+    const store = new FakeStore();
+    const setting = new Setting(
+      {} as vscode.ExtensionContext,
+      store,
+      "editor",
+      "defaultFormatter",
+      "Shopify.ruby-lsp",
+      undefined
+    );
+
+    setting.update(OverrideType.Workspace);
+
+    assert.strictEqual(store.get("editor", "defaultFormatter"), undefined);
+    assert.strictEqual(
+      store.get("editor", "defaultFormatter", false),
       "Shopify.ruby-lsp"
     );
   });


### PR DESCRIPTION
### Motivation

Closes #68

We always apply our setting recommendations on the global (user) settings. However, if a workspace setting exists (under `.vscode/settings.json`) it will always take precedence over what we configure and this can be confusing for users that expect out recommendation to be applied.

### Implementation

While trying to work on this, I realized the code was getting way too complicated to navigate and make changes, so I had to make a refactor first to facilitate this change.
1. Moved the test's `FakeStore` to a separate file so that other tests can use it too
2. Moved some interfaces and constants into `configurationStore`, so that multiple classes can access it
3. Extracted a `Setting` class, which is now responsible for everything related to a single setting, like checking whether the stored value is different from the recommended one, verifying if it's shadowed by a workspace setting or returning their full name
4. Made the changes in `Configuration` to warn users about workspace settings that will take precedence over our recommendations. When the user selects approve all overrides, we warn them at the end which settings are not going to be applied for that project. When selecting decide for each, we warn them for each setting and provide the chance to update the user settings, the workspace settings or both

### Manual tests

Because of caching, these can be a little tricky. Before each test scenario:
1. Delete the recommended defaults from your JSON settings
2. Change the version in `package.json` to a fake one, to bust the cache (e.g.: 0.0.3-apsldapskd). Has to be different every time

**Scenario 1 - Approving all overrides with no shadowed settings**
1. Don't forget the steps before each scenario
2. On this branch, start the debugging with F5 and open a project that does not have workspace settings shadowing our recommendations
3. Click approve all
4. Verify all recommendations are applied
5. Verify no warnings are displayed

**Scenario 2 - Approving all overrides with shadowed settings**
1. Don't forget the steps before each scenario
2. On this branch, start the debugging with F5 and open a project that has at least one setting with a different value than the recommended one in `.vscode/settings.json` 
3. Click approve all
4. Verify all recommendations are applied
5. Verify a warning is displayed for the settings that are shadowed

**Scenario 3 - Deciding for each with no shadowed settings**
1. Don't forget the steps before each scenario
2. On this branch, start the debugging with F5 and open a project that does not have workspace settings shadowing our recommendations
3. Click decide for each
4. Verify that decisions are properly applied
5. Verify no warnings are displayed when deciding overrides

**Scenario 4 - Deciding for each with shadowed settings**
1. Don't forget the steps before each scenario
2. On this branch, start the debugging with F5 and open a project that has at least one setting with a different value than the recommended one in `.vscode/settings.json`
3. Click decide for each
4. Verify that the decision dialogue warns about the setting being shadowed
5. Verify there are buttons for Override, Override workspace, Override both and Cancel
6. Verify that decisions are properly applied