### PR TITLE
Add command to clear state

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,12 @@
   "contributes": {
     "commands": [
       {
-        "command": "ruby.force_apply_defaults",
-        "title": "Ruby: Force apply defaults"
+        "command": "rubyExtensionsPack.forceApplyDefaults",
+        "title": "Ruby extensions pack: Force apply defaults"
+      },
+      {
+        "command": "rubyExtensionsPack.clearState",
+        "title": "Ruby extensions pack: Clear cache and recommended settings"
       }
     ]
   },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -89,6 +89,22 @@ export class Configuration {
     }
   }
 
+  clearState() {
+    // Clear setting config and cache
+    this.settings.forEach((setting) => setting.clear());
+
+    // Clear approval cache
+    const existingKeys = this.context.globalState
+      .keys()
+      .filter((key) =>
+        key.match(/shopify\.ruby-extensions-pack\..*\.approved_all_overrides/)
+      );
+
+    existingKeys.forEach((key) => {
+      this.context.globalState.update(key, undefined);
+    });
+  }
+
   // Recursively step through each setting and prompt the user for their override decision
   private recursivelyPromptSetting(settingIndex: number) {
     // Exit when we're at the end of the list

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,8 +7,15 @@ export async function activate(context: vscode.ExtensionContext) {
   configuration.applyDefaults();
 
   context.subscriptions.push(
-    vscode.commands.registerCommand("ruby.force_apply_defaults", () =>
-      configuration.applyDefaults(true)
+    vscode.commands.registerCommand(
+      "rubyExtensionsPack.forceApplyDefaults",
+      () => configuration.applyDefaults(true)
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("rubyExtensionsPack.clearState", () =>
+      configuration.clearState()
     )
   );
 }

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -83,6 +83,14 @@ export class Setting {
     return JSON.stringify(this.value);
   }
 
+  clear() {
+    this.configurationEntry.update(this.name, undefined, true, true);
+    this.context.globalState.update(
+      `${CANCELLED_OVERRIDES_KEY}.${this.name}`,
+      undefined
+    );
+  }
+
   async promptOverride(): Promise<OverrideType> {
     // If the user cancelled the override or if the setting does not need, don't prompt
     if (

--- a/src/test/fakeGlobalState.ts
+++ b/src/test/fakeGlobalState.ts
@@ -1,0 +1,30 @@
+import * as vscode from "vscode";
+
+export default class FakeGlobalState implements vscode.Memento {
+  private storage: { [key: string]: any } = {};
+
+  constructor() {
+    this.storage = {};
+  }
+
+  update(key: string, value: any): Thenable<void> {
+    if (value === undefined) {
+      delete this.storage[key];
+      return Promise.resolve();
+    }
+
+    return (this.storage[key] = value);
+  }
+
+  get(name: string) {
+    return this.storage[name];
+  }
+
+  keys() {
+    return Object.keys(this.storage);
+  }
+
+  setKeysForSync(_keys: ReadonlyArray<string>): void {
+    // noop
+  }
+}


### PR DESCRIPTION
Add a command to clear the cache and the recommended settings. This will make it easier to perform manual tests and also reset states if things aren't working properly.

The command
1. Clears the override decision cache
2. Clears the individual setting cancellation cache
3. Removes the recommend setting

### Manual tests

1. Start the extension on this branch
2. CMD + SHIFT + P to open the command palette and run the `Clear cache and recommended settings` command
3. Reload the extension
4. Verify that the recommended settings have been removed from your user JSON settings
5. Verify you get prompted once again to make an override selection 