### PR TITLE
Disable format on save

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -24,7 +24,7 @@ export const DEFAULT_CONFIGS = [
     scope: { languageId: "ruby" },
     section: "editor",
     name: "formatOnSave",
-    value: true,
+    value: false,
   },
   { section: "byesig", name: "fold", value: false },
   { section: "byesig", name: "enabled", value: true },


### PR DESCRIPTION
We been [receiving reports](https://github.com/Shopify/ruby-lsp/issues/146) of the Ruby LSP's formatting hanging on save. While we investigate the issue, let's disable it.