### PR TITLE
Bump to version 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.0.4]
+
+- Cleanup previous override approvals (https://github.com/Shopify/vscode-shopify-ruby/pull/99)
+- Warn users about settings shadowed by workspace settings (https://github.com/Shopify/vscode-shopify-ruby/pull/100)
+- Add command to clear cache and settings (https://github.com/Shopify/vscode-shopify-ruby/pull/117)
+- Disable format on save temporarily (https://github.com/Shopify/vscode-shopify-ruby/pull/123)
+- Configure Ruby files to use 2 spaces of indentation (https://github.com/Shopify/vscode-shopify-ruby/pull/125)
+
 ## [0.0.3]
 
 - Add the Ruby LSP to the pack (https://github.com/Shopify/vscode-shopify-ruby/pull/85)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/Shopify/vscode-shopify-ruby"
   },
-  "version": "0.0.3",
+  "version": "0.0.4",
   "engines": {
     "vscode": "^1.63.0"
   },


### PR DESCRIPTION
Bump to `0.0.4` so that we can release
- disabling format on save
- shadowed settings warnings
- the clear state command

#### Manual tests

Please, assist in making sure everything is working fine for the release.
1. Start the extension on this branch
2. Verify you get prompted (since format on save no longer matches our recommendation)
3. Choose whether to accept all overrides or decide for each
4. Verify that format on save is disabled properly (only for the `[ruby]` configuration scope)