### PR TITLE
Configure Ruby files to use 2 spaces for indentation

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -26,6 +26,18 @@ export const DEFAULT_CONFIGS = [
     name: "formatOnSave",
     value: false,
   },
+  {
+    scope: { languageId: "ruby" },
+    section: "editor",
+    name: "tabSize",
+    value: 2,
+  },
+  {
+    scope: { languageId: "ruby" },
+    section: "editor",
+    name: "insertSpaces",
+    value: true,
+  },
   { section: "byesig", name: "fold", value: false },
   { section: "byesig", name: "enabled", value: true },
   { section: "byesig", name: "opacity", value: 0.5 },


### PR DESCRIPTION
We have received some reports that Ruby files are sometimes incorrectly configured to use tabs instead of spaces. We can fix that easily by pushing the recommended settings for Ruby.
