### PR TITLE
Change button wording for clarity

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -141,12 +141,12 @@ export class Configuration {
   private async promptOverrideStatus(): Promise<OverridesStatus> {
     const response = await vscode.window.showInformationMessage(
       "Would you like to apply all of the suggested configuration defaults?",
-      "Override All",
+      "Apply All",
       "Decide for each",
       "Cancel"
     );
 
-    if (response === "Override All") {
+    if (response === "Apply All") {
       this.context.globalState.update(
         APPROVED_ALL_OVERRIDES_KEY,
         OverridesStatus.ApprovedAll

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -9,6 +9,7 @@ import {
 
 export enum OverrideType {
   Global = "Override",
+  ApplyNew = "Apply",
   Workspace = "Override workspace",
   Both = "Override both",
   None = "Cancel",
@@ -101,7 +102,19 @@ export class Setting {
     }
 
     let message = `The setting ${this.fullName()} doesn't match our recommendation (${this.printableValue()})`;
-    let options: OverrideType[] = [OverrideType.Global, OverrideType.None];
+    let exists = true;
+    if (
+      this.existingConfig === undefined ||
+      this.existingConfig?.globalValue === undefined
+    ) {
+      message = `No configuration found for ${this.fullName()}. Would you like to apply the suggested default (${this.printableValue()})?`;
+      exists = false;
+    }
+
+    let options: OverrideType[] = [
+      exists ? OverrideType.Global : OverrideType.ApplyNew,
+      OverrideType.None,
+    ];
 
     if (this.shadowedByWorkspaceSetting) {
       message = message.concat(" and is shadowed by a workspace setting");


### PR DESCRIPTION
### Motivation
Closes #116 

During set up, having the button say `Apply` makes more sense than `Override` in cases when there is no default to override.

### Implementation
1. Changed the button `Override All` for the question "Would you like to apply all of the suggested configuration defaults?" to `Apply All`
2. Modified the `promptOverride()` function to check if there is an existing config for the setting and if not to change the message & button options displayed

**Setting exists**
<img width="565" alt="Screen Shot 2022-06-14 at 3 32 33 PM" src="https://user-images.githubusercontent.com/38566184/173673327-777879cd-3e5c-438e-a689-022b1da66dd5.png">
**Setting does not exist**
<img width="563" alt="Screen Shot 2022-06-14 at 3 33 04 PM" src="https://user-images.githubusercontent.com/38566184/173673432-2ae23097-78e2-44a7-a085-dac5e4163913.png">

### Manual Testing
1. Open up a repository with the debugger on VSCode (`Function + F5`)
2. If prompted by the VSCode extension to apply the suggested configuration defaults, `Apply All`
3. Open up `settings.json`(not the default or workspace settings)
4. Delete some of the settings (e.g.,`byesig.opacity`)
5. Change some of the settings (`"bysig.showIcon": false` instead of `true`)
6. Stop the debugger, go into `package.json` in `vscode-shopify-ruby` and change the `version` number by appending something (e.g., `0.0.4-1`)
7. Restart the debugger, when prompted to apply the suggested configuration defaults choose `Decide for each`
8. You should see different prompting messages & buttons depending on what you modified in `settings.json`