### PR TITLE
Save setting when "Apply" is clicked

### DIFF
--- a/src/setting.ts
+++ b/src/setting.ts
@@ -70,7 +70,7 @@ export class Setting {
       this.configurationEntry.update(
         this.name,
         this.value,
-        type === OverrideType.Global,
+        type === OverrideType.Global || type === OverrideType.ApplyNew,
         true
       );
     }


### PR DESCRIPTION
### Motivation
Closes #134 

During set up, clicking `Apply` was not updating `settings.json` and users were being reprompted to apply settings each time they reloaded the application. This happened because `Override.ApplyNew` was introduced in #133 but that change wasn't reflected in the `update` function of `setting.ts`. 

### Implementation
In the `update` function in `setting.ts` it was updating one value if `type === OverrideType.Global` but I introduced `OverrideType.ApplyNew` in a previous PR and didn't update this logic so this was resolving to false when it should've resolved to true which meant it wasn't saving the settings. I fixed the logic to resolve to true if `type === OverrideType.ApplyNew` as well.

### Manual Testing
1. Open up a repository with the debugger on VSCode (`fn + F5`)
2. Open up `settings.json`(user settings) 
3. If prompted by the VSCode extension to apply the suggested configuration defaults, `Apply All`
4. Search for "Ruby extensions pack: Clear cache and recommended settings" and click it
6. Notice the `settings.json` folder has been emptied of the default configs
7. Restart the debugger, when prompted to apply the suggested configuration defaults choose `Decide for each`
8. Click `Apply` for each setting
9. Restart the debugger. You should not be prompted again to apply new settings and all of the new settings should be present in `settings.json`