### PR TITLE
Enable formatOnSave

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -24,7 +24,7 @@ export const DEFAULT_CONFIGS = [
     scope: { languageId: "ruby" },
     section: "editor",
     name: "formatOnSave",
-    value: false,
+    value: true,
   },
   {
     scope: { languageId: "ruby" },


### PR DESCRIPTION
Reverts Shopify/vscode-shopify-ruby#123

This was fixed in https://github.com/Shopify/ruby-lsp/pull/149
🎩 and it seemed to work nicely.