### PR TITLE
Bump to version 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.0.6]
+
+- Save setting when "Apply" is selected (https://github.com/Shopify/vscode-shopify-ruby/pull/143)
+- Enable formatOnSave (https://github.com/Shopify/vscode-shopify-ruby/pull/144)
+
 ## [0.0.5]
 
 - Clarify whether users are adding or overriding a setting during setup (https://github.com/Shopify/vscode-shopify-ruby/pull/133)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/Shopify/vscode-shopify-ruby"
   },
-  "version": "0.0.5",
+  "version": "0.0.6",
   "engines": {
     "vscode": "^1.63.0"
   },


### PR DESCRIPTION
Bump to `0.0.6` so that we can release:
- Save setting when "Apply" is selected (https://github.com/Shopify/vscode-shopify-ruby/pull/143)
- Enable formatOnSave (https://github.com/Shopify/vscode-shopify-ruby/pull/144)

**Manual tests**

Please, assist in making sure everything is working fine for the release

1. Start the extension on this branch
2. Verify you get prompted 
3. Wipe the state
4. Click `Decide for each`
5. Click `Accept` for each setting and ensure user `settings.json` is populated
6. Verify you aren't re-prompted to apply new settings once you restart the extension