### PR TITLE
Preconfigure editor ruler based on Shopify style guide

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -44,6 +44,7 @@ export const DEFAULT_CONFIGS = [
   { section: "byesig", name: "showIcon", value: false },
   { section: "files", name: "trimTrailingWhitespace", value: true },
   { section: "files", name: "insertFinalNewline", value: true },
+  { section: "editor", name: "rulers", value: [120] },
 ];
 
 export enum OverridesStatus {


### PR DESCRIPTION
Shopify style guide: https://ruby-style-guide.shopify.dev/#:~:text=Limit%20lines%20to%20120%20characters.

Resolves: https://github.com/Shopify/vscode-shopify-ruby/issues/122