### PR TITLE
Bump to version v0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.0.7]
+
+- Add auto-configuration for the ruler (https://github.com/Shopify/vscode-shopify-ruby/pull/146)
+- Add the extension logo (https://github.com/Shopify/vscode-shopify-ruby/pull/152)
+
 ## [0.0.6]
 
 - Save setting when "Apply" is selected (https://github.com/Shopify/vscode-shopify-ruby/pull/143)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/Shopify/vscode-shopify-ruby"
   },
   "icon": "icon.png",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "engines": {
     "vscode": "^1.63.0"
   },


### PR DESCRIPTION
Bump to version 0.0.7. The version includes our new logo and the configuration for the editor ruler.