### PR TITLE
Deprecate and remove rebornix-ruby 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@
 
 This extension pack contains an opinionated collection of pre-configured extensions for Ruby development in VS Code:
 
-- [Ruby](https://marketplace.visualstudio.com/items?itemName=rebornix.ruby)
+- [ruby-lsp](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp)
 - [shadowenv](https://marketplace.visualstudio.com/items?itemName=Shopify.vscode-shadowenv)
 - [Ruby Sorbet](https://marketplace.visualstudio.com/items?itemName=sorbet.sorbet-vscode-extension)
 - [VSCode rdbg Ruby Debugger](https://marketplace.visualstudio.com/items?itemName=koichisasada.vscode-rdbg)
 - [byesig](https://marketplace.visualstudio.com/items?itemName=itarato.byesig)
-- [ruby-lsp](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This extension pack contains an opinionated collection of pre-configured extensions for Ruby development in VS Code:
 
-- [ruby-lsp](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp)
+- [Ruby LSP](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp)
 - [shadowenv](https://marketplace.visualstudio.com/items?itemName=Shopify.vscode-shadowenv)
 - [Ruby Sorbet](https://marketplace.visualstudio.com/items?itemName=sorbet.sorbet-vscode-extension)
 - [VSCode rdbg Ruby Debugger](https://marketplace.visualstudio.com/items?itemName=koichisasada.vscode-rdbg)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "onStartupFinished"
   ],
   "extensionPack": [
-    "rebornix.ruby",
     "Shopify.vscode-shadowenv",
     "sorbet.sorbet-vscode-extension",
     "koichisasada.vscode-rdbg",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -104,7 +104,7 @@ export class Configuration {
 
   async showRebornixDeprecationWarning(): Promise<void> {
     await vscode.window.showWarningMessage(
-      "The rebornix-ruby plugin is deprecated."
+      "The rebornix-ruby plugin is deprecated. Remove any custom configurations for the plugin from your settings."
     );
   }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -48,10 +48,9 @@ export enum OverridesStatus {
 }
 
 export class Configuration {
-  settings: Setting[];
-  context: vscode.ExtensionContext;
-  configurationStore: ConfigurationStore;
+  private context: vscode.ExtensionContext;
   private overrideStatus: OverridesStatus | undefined;
+  private settings: Setting[];
   private allSettingsMatch: boolean;
 
   constructor(
@@ -71,7 +70,6 @@ export class Configuration {
     );
     this.allSettingsMatch = this.settings.every((setting) => setting.match());
     this.context = context;
-    this.configurationStore = configurationStore;
     this.overrideStatus = this.getAproveAll();
   }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -8,12 +8,12 @@ import {
 import { Setting, OverrideType } from "./setting";
 
 export const DEFAULT_CONFIGS = [
-  { section: "ruby", name: "useBundler", value: true },
-  { section: "ruby", name: "useLanguageServer", value: false },
-  { section: "ruby", name: "lint", value: { rubocop: false } },
-  { section: "ruby", name: "codeCompletion", value: false },
-  { section: "ruby", name: "intellisense", value: false },
-  { section: "ruby", name: "format", value: false },
+  { section: "ruby", name: "useBundler", value: undefined },
+  { section: "ruby", name: "useLanguageServer", value: undefined },
+  { section: "ruby", name: "lint", value: undefined },
+  { section: "ruby", name: "codeCompletion", value: undefined },
+  { section: "ruby", name: "intellisense", value: undefined },
+  { section: "ruby", name: "format", value: undefined },
   {
     scope: { languageId: "ruby" },
     section: "editor",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -8,12 +8,6 @@ import {
 import { Setting, OverrideType } from "./setting";
 
 export const DEFAULT_CONFIGS = [
-  { section: "ruby", name: "useBundler", value: undefined },
-  { section: "ruby", name: "useLanguageServer", value: undefined },
-  { section: "ruby", name: "lint", value: undefined },
-  { section: "ruby", name: "codeCompletion", value: undefined },
-  { section: "ruby", name: "intellisense", value: undefined },
-  { section: "ruby", name: "format", value: undefined },
   {
     scope: { languageId: "ruby" },
     section: "editor",
@@ -54,9 +48,10 @@ export enum OverridesStatus {
 }
 
 export class Configuration {
-  private context: vscode.ExtensionContext;
+  settings: Setting[];
+  context: vscode.ExtensionContext;
+  configurationStore: ConfigurationStore;
   private overrideStatus: OverridesStatus | undefined;
-  private settings: Setting[];
   private allSettingsMatch: boolean;
 
   constructor(
@@ -76,6 +71,7 @@ export class Configuration {
     );
     this.allSettingsMatch = this.settings.every((setting) => setting.match());
     this.context = context;
+    this.configurationStore = configurationStore;
     this.overrideStatus = this.getAproveAll();
   }
 
@@ -100,12 +96,6 @@ export class Configuration {
     } else {
       this.recursivelyPromptSetting(0);
     }
-  }
-
-  async showRebornixDeprecationWarning(): Promise<void> {
-    await vscode.window.showWarningMessage(
-      "The rebornix-ruby plugin is deprecated. Remove any custom configurations for the plugin from your settings."
-    );
   }
 
   clearState() {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -102,6 +102,12 @@ export class Configuration {
     }
   }
 
+  async showRebornixDeprecationWarning(): Promise<void> {
+    await vscode.window.showWarningMessage(
+      "The rebornix-ruby plugin is deprecated."
+    );
+  }
+
   clearState() {
     // Clear setting config and cache
     this.settings.forEach((setting) => setting.clear());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,11 +43,12 @@ export async function showRebornixDeprecationWarning(
   context: vscode.ExtensionContext
 ): Promise<void> {
   const response = await vscode.window.showWarningMessage(
-    "The rebornix-ruby plugin is deprecated - remove any custom configurations for the plugin from your settings.",
-    "Remove configurations"
+    "The Ruby LSP has fully replaced the Ruby plugin functionality. Uninstall the `rebornix.ruby` and the `wingrunr21.vscode-ruby` extensions. Click `Cleanup` to remove related configuration.",
+    "Cleanup",
+    "Cancel"
   );
 
-  if (response === "Remove configurations") {
+  if (response === "Cleanup") {
     const settings = DEPRECATED_REBORNIX_RUBY_CONFIG.map(
       (config) =>
         new Setting(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,8 @@ import { Configuration } from "./configuration";
 
 export async function activate(context: vscode.ExtensionContext) {
   const configuration = new Configuration(vscode.workspace, context);
+
+  configuration.showRebornixDeprecationWarning();
   configuration.applyDefaults();
 
   context.subscriptions.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,15 @@
 import * as vscode from "vscode";
 
 import { Configuration } from "./configuration";
+import { Setting } from "./setting";
 
 export async function activate(context: vscode.ExtensionContext) {
   const configuration = new Configuration(vscode.workspace, context);
 
-  configuration.showRebornixDeprecationWarning();
+  if (vscode.extensions.getExtension("rebornix.ruby")) {
+    showRebornixDeprecationWarning(configuration);
+  }
+
   configuration.applyDefaults();
 
   context.subscriptions.push(
@@ -23,3 +27,38 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {}
+
+export const DEPRECATED_REBORNIX_RUBY_CONFIG = [
+  { section: "ruby", name: "useBundler", value: undefined },
+  { section: "ruby", name: "useLanguageServer", value: undefined },
+  { section: "ruby", name: "lint", value: undefined },
+  { section: "ruby", name: "codeCompletion", value: undefined },
+  { section: "ruby", name: "intellisense", value: undefined },
+  { section: "ruby", name: "format", value: undefined },
+];
+
+// TODO: This function and surrounding code should be
+// removed in the next version after rebornix.ruby is deprecated
+export async function showRebornixDeprecationWarning(
+  configuration: Configuration
+): Promise<void> {
+  const response = await vscode.window.showWarningMessage(
+    "The rebornix-ruby plugin is deprecated - remove any custom configurations for the plugin from your settings.",
+    "Remove configurations"
+  );
+
+  if (response === "Remove configurations") {
+    configuration.settings = DEPRECATED_REBORNIX_RUBY_CONFIG.map(
+      (config) =>
+        new Setting(
+          configuration.context,
+          configuration.configurationStore,
+          config.section,
+          config.name,
+          undefined,
+          undefined
+        )
+    );
+    configuration.settings.forEach((setting) => setting.update());
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,6 +58,6 @@ export async function showRebornixDeprecationWarning(
           undefined
         )
     );
-    settings.forEach((setting) => setting.update());
+    settings.forEach((setting) => setting.clear());
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const configuration = new Configuration(vscode.workspace, context);
 
   if (vscode.extensions.getExtension("rebornix.ruby")) {
-    showRebornixDeprecationWarning(configuration);
+    showRebornixDeprecationWarning(context);
   }
 
   configuration.applyDefaults();
@@ -40,7 +40,7 @@ export const DEPRECATED_REBORNIX_RUBY_CONFIG = [
 // TODO: This function and surrounding code should be
 // removed in the next version after rebornix.ruby is deprecated
 export async function showRebornixDeprecationWarning(
-  configuration: Configuration
+  context: vscode.ExtensionContext
 ): Promise<void> {
   const response = await vscode.window.showWarningMessage(
     "The rebornix-ruby plugin is deprecated - remove any custom configurations for the plugin from your settings.",
@@ -48,17 +48,16 @@ export async function showRebornixDeprecationWarning(
   );
 
   if (response === "Remove configurations") {
-    configuration.settings = DEPRECATED_REBORNIX_RUBY_CONFIG.map(
+    const settings = DEPRECATED_REBORNIX_RUBY_CONFIG.map(
       (config) =>
         new Setting(
-          configuration.context,
-          configuration.configurationStore,
+          context,
+          vscode.workspace,
           config.section,
           config.name,
-          undefined,
           undefined
         )
     );
-    configuration.settings.forEach((setting) => setting.update());
+    settings.forEach((setting) => setting.update());
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export function deactivate() {}
 
-export const DEPRECATED_REBORNIX_RUBY_CONFIG = [
+const DEPRECATED_REBORNIX_RUBY_CONFIG = [
   { section: "ruby", name: "useBundler", value: undefined },
   { section: "ruby", name: "useLanguageServer", value: undefined },
   { section: "ruby", name: "lint", value: undefined },


### PR DESCRIPTION
# Motivation

Start the process of deprecating and removing Rebornix Ruby from the extension pack

# Changes

This PR introduces some changes from the list of todo in: https://github.com/Shopify/ruby-dev-exp-issues/issues/533#issuecomment-1129185226 

- Remove Rebornix.Ruby from the extensions pack
-  Set all of the Rebornix.Ruby related configuration values to be undefined, so that they are removed from people's configuration
- Simple warning that Rebornix.Ruby is deprecated

# Test 

* Make sure there are some `rebornix-ruby` configurations in your settings.json, example: 
```json
    "ruby.format": "prettier",
    "ruby.lint": {
        "enabled": true,
        "ignored": [
            "**/vendor/**",
            "**/node_modules/**",
            "**/bower_components/**"
        ],
        "rubocop": {
            "enabled": true,
            "ignored": [
                "**/vendor/**",
                "**/node_modules/**",
                "**/bower_components/**"
            ]
        }
    },
```

* Start the debug server
* See the warning and hit `Remove configurations`