### PR TITLE
Auto-enable semantic highlighting for Ruby

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -45,6 +45,12 @@ export const DEFAULT_CONFIGS = [
   { section: "files", name: "trimTrailingWhitespace", value: true },
   { section: "files", name: "insertFinalNewline", value: true },
   { section: "editor", name: "rulers", value: [120] },
+  {
+    scope: { languageId: "ruby" },
+    section: "editor.semanticHighlighting",
+    name: "enabled",
+    value: true,
+  },
 ];
 
 export enum OverridesStatus {


### PR DESCRIPTION
The default value of the `semanticHighlighting.enabled` configuration is `configuredByTheme`. This means that, if the theme doesn't turn on semantic highlighting, folks are actually not getting any of it.

I propose we turn this on by default, given that the Ruby LSP can provide semantic highlighting. Thoughts?