### PR TITLE
Enable format on type for Ruby

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -23,6 +23,12 @@ export const DEFAULT_CONFIGS = [
   {
     scope: { languageId: "ruby" },
     section: "editor",
+    name: "formatOnType",
+    value: true,
+  },
+  {
+    scope: { languageId: "ruby" },
+    section: "editor",
     name: "tabSize",
     value: 2,
   },


### PR DESCRIPTION
The work on https://github.com/Shopify/vscode-ruby-lsp/pull/193 and https://github.com/Shopify/ruby-lsp/pull/253 only works if `formatOnType` is enabled.

This PR enables it for Ruby.