### PR TITLE
Ignore unknown yarn engines

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--ignore-engines true


### PR DESCRIPTION
This is a very minor improvement. When we run yarn commands, it complains that it doesn't recognize the engine "vscode". We can configure yarn to ignore unknown engines, which we already do in `vscode-ruby-lsp`.