### PR TITLE
Add release configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+      - chore
+    authors:
+      - dependabot
+  categories:
+    - title: 🚧 Breaking Changes
+      labels:
+        - breaking-change
+    - title: ✨ Enhancements
+      labels:
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - bugfix
+    - title: 🛠 Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
While release `v0.1.0` I noticed we didn't have our standard release configuration to generate the notes.