### PR TITLE
Indicate the Spinel theme is intended for dark mode

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -133,7 +133,7 @@ export class Configuration {
     }
 
     const response = await vscode.window.showInformationMessage(
-      "The new Spinel theme is tailored for Ruby code. Would you like to try it?",
+      "The new Spinel theme (dark) is tailored for Ruby code. Would you like to try it?",
       "Yes",
       "No"
     );


### PR DESCRIPTION
Although it's mentioned in the README, if people are upgrading then they would be unlikely to see that.