### PR TITLE
Add diff syntax highlight

### DIFF
--- a/themes/dark_spinel.json
+++ b/themes/dark_spinel.json
@@ -372,6 +372,43 @@
         "foreground": "#ce74f8",
         "fontStyle": "italic"
       }
+    },
+    {
+      "name": "diff: header",
+      "scope": [
+        "meta.diff",
+        "meta.diff.header",
+        "punctuation.definition.to-file.diff",
+        "punctuation.definition.from-file.diff",
+        "punctuation.definition.range.diff"
+      ],
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#18B5E4"
+      }
+    },
+    {
+      "name": "diff: deleted",
+      "scope": ["markup.deleted", "punctuation.definition.deleted.diff"],
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#DD5555"
+      }
+    },
+    {
+      "name": "diff: changed",
+      "scope": "markup.changed",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#FF9A3B"
+      }
+    },
+    {
+      "name": "diff: inserted",
+      "scope": ["markup.inserted", "punctuation.definition.inserted.diff"],
+      "settings": {
+        "foreground": "#5AC16C"
+      }
     }
   ]
 }


### PR DESCRIPTION
Hello!
Here is a screenshot what a diff looks like in the `Solarized Dark` theme
![Screenshot 2023-04-20 at 2 07 15 PM](https://user-images.githubusercontent.com/923718/233455492-acc69f29-bd75-4bfb-9e57-40933ff5f0ad.png)
Here is the same diff in the `Spinel` theme
![Screenshot 2023-04-20 at 2 07 19 PM](https://user-images.githubusercontent.com/923718/233455494-21349264-1ac0-4d58-854f-709156b8cfe5.png)

I added the required tokens to make it work with Spinel, [based on the Solarized dark colors.](https://github.com/microsoft/vscode/blob/233c88aede868ca6906e9b23842793f0196d32c5/extensions/theme-solarized-dark/themes/solarized-dark-color-theme.json#L224-L257)

Result:
![image](https://user-images.githubusercontent.com/923718/233459742-d5b5a5bf-1d04-4892-be19-5b6785428ac1.png)

I'd be happy to adjust the colors to something more appropriate for the theme, if someone want to suggest what should be used.