### PR TITLE
Add RedHat YAML extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "Shopify.vscode-shadowenv",
     "sorbet.sorbet-vscode-extension",
     "koichisasada.vscode-rdbg",
-    "Shopify.ruby-lsp"
+    "Shopify.ruby-lsp",
+    "redhat.vscode-yaml"
   ],
   "contributes": {
     "commands": [


### PR DESCRIPTION
A few users have reported issues related to running Tapioca with an invalid YAML config file. This should help to prevent this, and will be generally useful in other cases where we need to edit YAML.

The extension is pending review in Kepler.