### PR TITLE
Scope all settings to Ruby

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -39,9 +39,30 @@ export const DEFAULT_CONFIGS = [
     name: "insertSpaces",
     value: true,
   },
-  { section: "files", name: "trimTrailingWhitespace", value: true },
-  { section: "files", name: "insertFinalNewline", value: true },
-  { section: "editor", name: "rulers", value: [120] },
+  {
+    scope: { languageId: "ruby" },
+    section: "files",
+    name: "trimTrailingWhitespace",
+    value: true,
+  },
+  {
+    scope: { languageId: "ruby" },
+    section: "files",
+    name: "insertFinalNewline",
+    value: true,
+  },
+  {
+    scope: { languageId: "ruby" },
+    section: "files",
+    name: "trimFinalNewlines",
+    value: true,
+  },
+  {
+    scope: { languageId: "ruby" },
+    section: "editor",
+    name: "rulers",
+    value: [120],
+  },
   {
     scope: { languageId: "ruby" },
     section: "editor.semanticHighlighting",


### PR DESCRIPTION
Scope all of our setting recommendations to only apply to the Ruby language. Also took the chance and added `trimFinalNewlines`, which ensures that there isn't more than one line at the end of the file.