### PR TITLE
Remove shadowenv extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 This extension pack contains an opinionated collection of pre-configured extensions for Ruby development in VS Code:
 
 - [Ruby LSP](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp)
-- [shadowenv](https://marketplace.visualstudio.com/items?itemName=Shopify.vscode-shadowenv)
 - [Ruby Sorbet](https://marketplace.visualstudio.com/items?itemName=sorbet.sorbet-vscode-extension)
 - [VSCode rdbg Ruby Debugger](https://marketplace.visualstudio.com/items?itemName=koichisasada.vscode-rdbg)
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "onStartupFinished"
   ],
   "extensionPack": [
-    "Shopify.vscode-shadowenv",
     "sorbet.sorbet-vscode-extension",
     "koichisasada.vscode-rdbg",
     "Shopify.ruby-lsp"


### PR DESCRIPTION
After https://github.com/Shopify/vscode-ruby-lsp/pull/699, we no longer need the shadowenv extension to be a part of the bundle.