### PR TITLE
Add missing `variable.other.object.property` scope

### DIFF
--- a/themes/dark_spinel.json
+++ b/themes/dark_spinel.json
@@ -98,6 +98,7 @@
         "keyword.operator.assignment.ruby",
         "entity.name.function.call.cpp",
         "entity.name.function.member.cpp",
+        "variable.other.object.property",
         "variable.other.property",
         "meta.brace.round.ts",
         "meta.brace.square.ts",


### PR DESCRIPTION
We were missing this scope and then properties defined with `#property` were highlighted inconsistently.