### PR TITLE
Revert display name change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruby-extensions-pack",
-  "displayName": "Ruby extension pack",
+  "displayName": "Ruby",
   "description": "An opinionated and auto-configured set of extensions for Ruby development",
   "license": "MIT",
   "publisher": "Shopify",


### PR DESCRIPTION
Revert the display name change made in #565 so that we can release. It appears we can't change the display name as it fails to publish the extension.