### PR TITLE
Update Readme with instruction to add Rubocop in Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ You may want to backup your `settings.json` file before trying this extension ou
 The recommended settings and their respective values can be found
 in the extension [configuration file](https://github.com/Shopify/vscode-shopify-ruby/blob/main/src/configuration.ts#L10).
 
+If using Rubocop, make sure to add rubocop in your Gemfile to get VS Code formatter to work.
+
+```ruby
+# Gemfile
+group :development do
+  gem "rubocop"
+end
+```
+
 ### Commands
 
 The commands offered to help manage the recommended settings are:


### PR DESCRIPTION
Related comment https://github.com/Shopify/vscode-shopify-ruby/issues/443#issuecomment-1567160768

> The Ruby LSP doesn't support running RuboCop from a global installation. It must be a part of your Gemfile or else it just gets ignored.